### PR TITLE
Possible performance increase. (Don't accept blindly though!)

### DIFF
--- a/js/jquery.multi-select.js
+++ b/js/jquery.multi-select.js
@@ -71,7 +71,7 @@
 
         if (!selectableLi.attr('disabled')){
           selectableLi.hide();
-          ms.val(newValues);
+          ms.find('option[value="' + value + '"]').attr('selected', 'selected');
           if(titleAttr){
             selectedLi.attr('title', titleAttr)
           }


### PR DESCRIPTION
Not sure if this is sensible. Works in my limited tests.

Using ms.val(newValues) when you've got very large multiselect box (~3000) is very, very slow. And I'm not sure why the already selected values need to be reselected either? (I may have missed something though.)

My tweak works just fine with 3000 items in the box (about 10 times faster for me). Not sure it works in all instances though, as I haven't tested it thoroughly.

Just thought it was worth raising as a point of discussion, rather than an official pull request.
