### PR TITLE
Bug in keepOrder

### DIFF
--- a/js/jquery.multi-select.js
+++ b/js/jquery.multi-select.js
@@ -137,6 +137,8 @@
                 if (selectedUlLis[i] && getIndexOf($(selectedUlLis[i]).attr('ms-value')) < index) {
                   $(selectedUlLis[i]).after(selectedLi);
                   break;
+                } else if (i == 0) {
+                  $(selectedUlLis[i]).before(selectedLi);
                 }
               }
             }


### PR DESCRIPTION
With the keepOrder property set, unless the first item is selected first, the other items prior to the initial one will not be displayed in the selected list.  I just added a check to see if loop has made it to 0 and if so append the new item before in the list.
