### PR TITLE
defined option classes should be passed to selectable/selected divs

### DIFF
--- a/js/jquery.multi-select.js
+++ b/js/jquery.multi-select.js
@@ -56,7 +56,7 @@
               optgroupCpt++;
             }
             if ($(this).is("option:not(option[value=''])")){
-              var selectableLi = $('<li class="ms-elem-selectable" ms-value="'+$(this).val()+'">'+$(this).text()+'</li>');
+              var selectableLi = $('<li class="ms-elem-selectable '+$(this).attr('class')+'" ms-value="'+$(this).val()+'">'+$(this).text()+'</li>');
             
               if ($(this).attr('title'))
                 selectableLi.attr('title', $(this).attr('title'));
@@ -96,9 +96,10 @@
       var ms = this,
           selectedOption = ms.find('option[value="'+value +'"]'),
           text = selectedOption.text(),
+          klass = selectedOption.attr('class'),
           titleAttr = selectedOption.attr('title');
       
-        var selectedLi = $('<li class="ms-elem-selected" ms-value="'+value+'">'+text+'</li>'),
+        var selectedLi = $('<li class="ms-elem-selected '+klass+'" ms-value="'+value+'">'+text+'</li>'),
             selectableUl = $('#ms-'+ms.attr('id')+' .ms-selectable ul'),
             selectedUl = $('#ms-'+ms.attr('id')+' .ms-selection ul'),
             selectableLi = selectableUl.children('li[ms-value="'+value+'"]'),        


### PR DESCRIPTION
I had some issues styling the selected/selectable divs based on the unique classes (polymorphic set of items) provided directly to the options.  This pull request adds support for this by passing any explicit classes from the options to their selectable/selected counterpart within multi-select.
