### PR TITLE
Styling consistent in IE8/IE7

### DIFF
--- a/css/multi-select.css
+++ b/css/multi-select.css
@@ -22,7 +22,7 @@
   -ms-transition: border linear 0.2s, box-shadow linear 0.2s;
   -o-transition: border linear 0.2s, box-shadow linear 0.2s;
   transition: border linear 0.2s, box-shadow linear 0.2s;
-    border: 1px solid #cccccc;
+  border: 1px solid #ccc;
   -webkit-border-radius: 3px;
   -moz-border-radius: 3px;
   border-radius: 3px;
@@ -48,39 +48,46 @@
 .ms-container ul{
   margin: 0;
   list-style-type: none;
+  padding: 0;
+}
+
+.ms-container .ms-optgroup-container{
+  width: 100%;
 }
 
 .ms-container ul.ms-list{
   width: 160px;
   height: 200px;
-  padding: 0px 0px;
+  padding: 0;
   overflow-y: auto;
 }
 
+.ms-container .ms-optgroup-label{
+  margin: 0;
+  padding: 5px 0px 0px 5px;
+  cursor: pointer;
+  color: #999;
+}
+
 .ms-container .ms-selectable li.ms-elem-selectable,
-.ms-container .ms-selection li.ms-elem-selected{
+.ms-container .ms-selection li.ms-elem-selection{
   border-bottom: 1px #eee solid;
   padding: 2px 10px;
   color: #555;
   font-size: 14px;
 }
 
+.ms-container .ms-selectable li.ms-hover,
+.ms-container .ms-selection li.ms-hover{
+  cursor: pointer;
+  color: #fff;
+  text-decoration: none;
+  background-color: #08c;
+}
+
 .ms-container .ms-selectable li.disabled,
 .ms-container .ms-selection li.disabled{
   background-color: #eee;
   color: #aaa;
-}
-
-.ms-container .ms-optgroup-label{
-  padding: 5px 0px 0px 5px;
-  cursor: pointer;
-  color: #999;
-}
-
-.ms-container li.ms-elem-selectable:not(.disabled).ms-hover,
-.ms-container .ms-selection li:not(.disabled).ms-hover{
-  cursor: pointer;
-  color: #ffffff;
-  text-decoration: none;
-  background-color: #0088cc;
+  cursor: text;
 }


### PR DESCRIPTION
Your plugin works great and as expected in older versions of IE, so I updated a little styling so it looks the same as well. Thanks, great work!

Modified the styling for:
- minor layout issues in IE7
- removed the :not selector, unsupported <IE9
- reordered rules for importance and overriding
- equalized specificity between normal, hover, and disabled states of
  element items
