### PR TITLE
Removed redundant .ms-container selector

### DIFF
--- a/css/multi-select.css
+++ b/css/multi-select.css
@@ -1,5 +1,4 @@
 .ms-container{
-.ms-container{
   background: transparent url('../img/switch.png') no-repeat 170px 80px;
 }
 


### PR DESCRIPTION
I noticed a duplicate .ms-container selector at the top of the CSS file when trying to compile multi-select with Sass.
