### PR TITLE
Improved hover-performance

### DIFF
--- a/js/jquery.multi-select.js
+++ b/js/jquery.multi-select.js
@@ -84,8 +84,10 @@
         that.activeMouse(that.$selectionUl);
         that.activeKeyboard(that.$selectionUl);
 
-        ms.on('focus', function(){
-          that.$selectableUl.focus();
+        ms.on('focus', function(e){
+          if (!$(e.relatedTarget).is('ul.ms-list')) {
+            that.$selectableUl.focus();
+          }
         })
       }
 
@@ -198,6 +200,11 @@
             e.stopPropagation();
             that.switchList($list);
             return;
+          case 9:
+            if (e.shiftKey) {
+              that.$element.focus().trigger(e);
+            }
+            return true;
         }
       });
     },


### PR DESCRIPTION
Every time you entered a list, you bound an mouseenter-event on every item in the list. This caused a very bad performance after some time.

With this change, you bind one delegated event on the list over all items.
