### PR TITLE
Add new options method. Possible fix for #78

### DIFF
--- a/js/jquery.multi-select.js
+++ b/js/jquery.multi-select.js
@@ -327,6 +327,14 @@
       this.refresh();
     },
 
+    'clear': function() {
+      for (var _index in this.$element.get(0).options) {
+        this.$element.get(0).options.remove(0);
+      }
+
+      this.refresh();
+    },
+
     'select' : function(value, method){
       if (typeof value === 'string'){ value = [value]; }
 


### PR DESCRIPTION
I've added simple method to add new options into select.

User will have to take care about creating option element by himself.
i.e.:

{{{
// Init option
var option = document.createElement('option');
option.value = 55;
option.innerHTML = 'Test';
// Add it
$('some_element').multiSelect('add', option);
}}

Please notify if you'll want to put new option creation into multiSelect, don't think it's best idea however.
