### PR TITLE
fix performance issue hiliting large lists

### DIFF
--- a/js/jquery.multi-select.js
+++ b/js/jquery.multi-select.js
@@ -301,9 +301,11 @@
 
     'activeMouse' : function($list){
       var that = this;
-
+      var lastMovedDom = false;
       $list.on('mousemove', function(){
-        var elems = $list.find(that.elemsSelector);
+        if (lastMovedDom === this) return;
+				lastMovedDom = this;
+				var elems = $list.find(that.elemsSelector);
 
         elems.on('mouseenter', function(){
           elems.removeClass('ms-hover');


### PR DESCRIPTION
Thanks for the useful selector!

We found that even on a fast machine, it was very slow to hilite with mouseover.

The mousemove event was doing a very heavy JQuery select every time the mouse moved a single pixel.

This is a quick fix so that the mousemove is only called once per DOM element - really, it is a hack to convert the mousemove to behave like a mouseenter instead.  

Although this fix works, it is a bit quick and dirty!

AP
John
