### PR TITLE
Fix handling of special characters in option values to avoid collision.

### DIFF
--- a/js/jquery.multi-select.js
+++ b/js/jquery.multi-select.js
@@ -27,7 +27,7 @@
     this.$selectableUl = $('<ul/>', { 'class': "ms-list", 'tabindex' : '-1' });
     this.$selectionUl = $('<ul/>', { 'class': "ms-list", 'tabindex' : '-1' });
     this.scrollTo = 0;
-    this.sanitizeRegexp = new RegExp("\\W+", 'gi');
+    this.sanitizeRegexp = new RegExp("\\W", 'gi');
     this.elemsSelector = 'li:visible:not(.ms-optgroup-label,.ms-optgroup-container,.'+options.disabledClass+')';
   };
 
@@ -445,7 +445,8 @@
     },
 
     sanitize: function(value, reg){
-      return(value.replace(reg, '_'));
+      var hex = function(m) { return '_x' + m.charCodeAt(0).toString(16); }; 
+      return(value.replace(reg, hex));
     }
   };
 


### PR DESCRIPTION
For example, in my select box values I had both 'C++' and 'C#' as
skill sets and they both were mapping to C_ for generated elementID.
The fix replaces each special character by '_x' + hex-value.
e.g. 'C++' is replaced by 'C_x2b_x2b'
