### PR TITLE
Escape HTML in option text.

### DIFF
--- a/js/jquery.multi-select.js
+++ b/js/jquery.multi-select.js
@@ -102,6 +102,10 @@
           ms = that.$element,
           attributes = "",
           $option = $(option);
+          
+      function escapeHtml(text){
+        return $("<div>").text(text).html();
+      }
 
       for (var cpt = 0; cpt < option.attributes.length; cpt++){
         var attr = option.attributes[cpt];
@@ -110,7 +114,7 @@
           attributes += attr.name+'="'+attr.value+'" ';
         }
       }
-      var selectableLi = $('<li '+attributes+'><span>'+$option.text()+'</span></li>'),
+      var selectableLi = $('<li '+attributes+'><span>'+escapeHtml($option.text())+'</span></li>'),
           selectedLi = selectableLi.clone(),
           value = $option.val(),
           elementId = that.sanitize(value, that.sanitizeRegexp);


### PR DESCRIPTION
Account for escaped HTML entities (eg. script tags) in option values.

Test case:
https://gist.github.com/ghedsouza/7663746
