### PR TITLE
Support non-english characters in items values

### DIFF
--- a/js/jquery.multi-select.js
+++ b/js/jquery.multi-select.js
@@ -445,7 +445,15 @@
     },
 
     sanitize: function(value, reg){
-      return(value.replace(reg, '_'));
+			var hash = 0, i, char;
+			if (value.length == 0) return hash;
+			var ls = 0;
+			for (i = 0, ls = value.length; i < ls; i++) {
+				char  = value.charCodeAt(i);
+				hash  = ((hash<<5)-hash)+char;
+				hash |= 0; // Convert to 32bit integer
+			}
+			return hash;
     }
   };
 


### PR DESCRIPTION
Currently if select items have their values other than english, their ids becomes all the same: "_-selection" (following line 140). It is resonable to use string hash instead of regexp.
