### PR TITLE
Fixed invalid bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -3,6 +3,6 @@
   "version": "0.9.8",
   "main": ["css/multi-select.css", "img/switch.png", "js/jquery.multi-select.js"],
   "dependencies" : {
-    "jquery" ">= 1.7.1"
+    "jquery" : ">=1.7.1"
   }
 }


### PR DESCRIPTION
Hi, i found simple typo in the bower.json.

We [versioneye](https://www.versioneye.com/) are currently analysing quality of Bower packages registered on Bower.io. That's how i found this typo.
