### PR TITLE
fix of destroy function plus corresponding tests

### DIFF
--- a/js/jquery.multi-select.js
+++ b/js/jquery.multi-select.js
@@ -342,6 +342,7 @@
 
     'destroy' : function(){
       $("#ms-"+this.$element.attr("id")).remove();
+      this.$element.css('position', '').css('left', '')
       this.$element.removeData('multiselect');
     },
 

--- a/test/spec/multiSelectSpec.js
+++ b/test/spec/multiSelectSpec.js
@@ -102,6 +102,26 @@ describe("multiSelect", function() {
     });
   });
 
+  describe('destroy', function(){
+
+    describe('destroy multi select', function(){
+      beforeEach(function(){
+        select.multiSelect();
+        msContainer = select.next();
+        select.multiSelect('destroy');
+      });
+
+      it('should show the original select', function(){
+        expect(select.css('position')).not.toBe('absolute');
+        expect(select.css('left')).not.toBe('-9999px');
+      });
+
+      it('should destroy the multiSelect container', function(){
+        expect(select.next().size()).toEqual(0);
+      });
+    });
+  });
+
   describe('optgroup', function(){
     var optgroupMsContainer, optgroupSelect, optgroupLabels;
 


### PR DESCRIPTION
When calling multiSelect with "destroy" parameter the original select was not restored any more.
This PR fixes this issue.

Btw. some of the other tests are failing.
