### PR TITLE
Bugfix: char is a reserved keyword for Javascript

### DIFF
--- a/js/jquery.multi-select.js
+++ b/js/jquery.multi-select.js
@@ -474,12 +474,12 @@
     },
 
     sanitize: function(value){
-      var hash = 0, i, char;
+      var hash = 0, i, character;
       if (value.length == 0) return hash;
       var ls = 0;
       for (i = 0, ls = value.length; i < ls; i++) {
-        char  = value.charCodeAt(i);
-        hash  = ((hash<<5)-hash)+char;
+        character  = value.charCodeAt(i);
+        hash  = ((hash<<5)-hash)+character;
         hash |= 0; // Convert to 32bit integer
       }
       return hash;


### PR DESCRIPTION
`char` was used as a variable name (it actually is a reserved keyword, check at the bottom of the page @ http://www.crockford.com/javascript/survey.html) and thus closure compiler throws ERROR and quits. This fix just renames the variable so that js can be minified.
