### PR TITLE
fix mouse hovering

### DIFF
--- a/js/jquery.multi-select.js
+++ b/js/jquery.multi-select.js
@@ -321,17 +321,9 @@
     },
 
     'activeMouse' : function($list){
-      var that = this;
-      var lastMovedDom = false;
-      $list.on('mousemove', function(){
-        if (lastMovedDom === this) return;
-				lastMovedDom = this;
-				var elems = $list.find(that.elemsSelector);
-
-        elems.on('mouseenter', function(){
-          elems.removeClass('ms-hover');
-          $(this).addClass('ms-hover');
-        });
+      $list.on('mouseenter', this.elemsSelector, function() {
+        $list.find('.ms-hover').removeClass('ms-hover');
+        $(this).addClass('ms-hover');
       });
     },
 


### PR DESCRIPTION
Hi, 

@camart commit b96e433e seems to break the mouse hovering. Try the first example on http://loudev.com/#demos. Hover the mouse onto 'elem1' on the right side, then select a few elements on the left, you'll find you can't hover on all newly appeared elements on the right.

Event delegation seems to be a good solution to #101. Please try http://jsfiddle.net/cntoplolicon/Jjx9G/ which uses the fixed code, compared with http://jsfiddle.net/cntoplolicon/3ep4y/ which uses commit a835773 right before b96e433e and has performance issues.
