### PR TITLE
use css :hover instead of ms-hover class

### DIFF
--- a/css/multi-select.css
+++ b/css/multi-select.css
@@ -77,8 +77,8 @@
   font-size: 14px;
 }
 
-.ms-container .ms-selectable li.ms-hover,
-.ms-container .ms-selection li.ms-hover{
+.ms-container .ms-selectable li:hover,
+.ms-container .ms-selection li:hover {
   cursor: pointer;
   color: #fff;
   text-decoration: none;


### PR DESCRIPTION
Is there a specific reason to the additional CSS class "ms-hover".
This could be done anyway with native CSS ":hover".

I would suggest to change this... PR in place if needed
