### PR TITLE
Remove item highlighting when mouse leaves list

### DIFF
--- a/js/jquery.multi-select.js
+++ b/js/jquery.multi-select.js
@@ -324,6 +324,10 @@
         $(this).parents('.ms-container').find(that.elemsSelector).removeClass('ms-hover');
         $(this).addClass('ms-hover');
       });
+
+      $('body').on('mouseleave', that.elemsSelector, function () {
+          $(this).parents('.ms-container').find(that.elemsSelector).removeClass('ms-hover');;
+      });
     },
 
     'refresh' : function() {


### PR DESCRIPTION
I didn't like that items stay highlighted when the mouse leaves the selection area, now they don't.
