### PR TITLE
added a fullHeader wrapper

### DIFF
--- a/js/jquery.multi-select.js
+++ b/js/jquery.multi-select.js
@@ -47,6 +47,10 @@
 
         this.$selectionUl.find('.ms-optgroup-label').hide();
 
+        if (that.options.fullHeader){
+          that.$container.append(that.options.fullHeader);
+        }
+
         if (that.options.selectableHeader){
           that.$selectableContainer.append(that.options.selectableHeader);
         }


### PR DESCRIPTION
Hi,
I have added an option for add html at start of $container
example:

```
    $('#multiselect').multiSelect({
      fullHeader: "<div>your magic html!</div>"
    }
```

example of search in both lists :

```
$('#multiselect').multiSelect({
  keepOrder: true,
  fullHeader: "<input type='text' id='multiselect_search' class='search-input' autocomplete='off' placeholder='Cerca'>",
  afterInit: function(ms){
    var that = this;
    var $search = $('#multiselect_search');
    selectableSearchString = '#'+that.$container.attr('id')+' .ms-elem-selectable:not(.ms-selected)',
    selectionSearchString = '#'+that.$container.attr('id')+' .ms-elem-selection.ms-selected';

    that.qs1 = $('#multiselect_search').quicksearch(selectableSearchString)
    .on('keydown', function(e){
      if (e.which === 40){
        that.$selectableUl.focus();
        return false;
      }
    });

    that.qs2 = $('#multiselect_search').quicksearch(selectionSearchString)
    .on('keydown', function(e){
      if (e.which == 40){
        that.$selectionUl.focus();
        return false;
      }
    });

  },
  afterSelect: function(){
    this.qs1.cache();
    this.qs2.cache();
  },
  afterDeselect: function(){
    this.qs1.cache();
    this.qs2.cache();
  }
});
```
