### PR TITLE
fix logic: add attributes to <li>

### DIFF
--- a/js/jquery.multi-select.js
+++ b/js/jquery.multi-select.js
@@ -98,20 +98,25 @@
     'generateLisFromOption' : function(option, index, $container){
       var that = this,
           ms = that.$element,
-          attributes = "",
+          attributes = {},
           $option = $(option);
 
       for (var cpt = 0; cpt < option.attributes.length; cpt++){
         var attr = option.attributes[cpt];
 
         if(attr.name !== 'value' && attr.name !== 'disabled'){
-          attributes += attr.name+'="'+attr.value+'" ';
+          attributes[attr.name] = attr.value;
         }
       }
-      var selectableLi = $('<li '+attributes+'><span>'+that.escapeHTML($option.text())+'</span></li>'),
+      var selectableLi = $('<li><span>'+that.escapeHTML($option.text())+'</span></li>'),
           selectedLi = selectableLi.clone(),
           value = $option.val(),
           elementId = that.sanitize(value);
+      
+      //copy attr of option to multi-select li
+      for (attr in attributes){
+        selectableLi.attr(attr, attributes[attr]);
+      }
 
       selectableLi
         .data('ms-value', value)

--- a/js/jquery.multi-select.js
+++ b/js/jquery.multi-select.js
@@ -116,6 +116,7 @@
       //copy attr of option to multi-select li
       for (var attrname in attributes){
         selectableLi.attr(attrname, attributes[attrname]);
+        selectedLi.attr(attrname, attributes[attrname]);
       }
 
       selectableLi

--- a/js/jquery.multi-select.js
+++ b/js/jquery.multi-select.js
@@ -114,8 +114,8 @@
           elementId = that.sanitize(value);
       
       //copy attr of option to multi-select li
-      for (attr in attributes){
-        selectableLi.attr(attr, attributes[attr]);
+      for (var attrname in attributes){
+        selectableLi.attr(attrname, attributes[attrname]);
       }
 
       selectableLi


### PR DESCRIPTION
Previous attributes are added to li as a string, which will cause problem under IE. IE will add some quotes "" automatically, which will mess up a string. e.g. if use <option style="background: url(http://www.xx.com/xx.jpg)"> in option, img is not displayed under IE, because IE will add "" around the link, change it to url("http://www.xx.com/xx.jpg");

Treat attribute as what it is supposed to be, AN OBJECT, the string and quote issue can be solved.
