### PR TITLE
Add max-width to .ms-container

### DIFF
--- a/css/multi-select.css
+++ b/css/multi-select.css
@@ -1,6 +1,7 @@
 .ms-container{
   background: transparent url('../img/switch.png') no-repeat 50% 50%;
   width: 370px;
+  max-width: 100%;
 }
 
 .ms-container:after{


### PR DESCRIPTION
In mobile platform or a modal, it's easy to happen that the multiselect-container exceeds the gird.
So a add a style attribute(max-width: 100%) to .ms-container, I think that may be fined.
