### PR TITLE
Fix Memory leak from elements focus event

### DIFF
--- a/js/jquery.multi-select.js
+++ b/js/jquery.multi-select.js
@@ -340,6 +340,7 @@
 
     'destroy' : function(){
       $("#ms-"+this.$element.attr("id")).remove();
+      this.$element.off('focus');
       this.$element.css('position', '').css('left', '')
       this.$element.removeData('multiselect');
     },


### PR DESCRIPTION
Not sure why this one event was causing a memory leak but in our SPA it was. If this was not causing issues for anyone else then there is no harm in turning off the event and this change will have no ill side effects