### PR TITLE
Fix addOption when 'nested' specified

### DIFF
--- a/js/jquery.multi-select.js
+++ b/js/jquery.multi-select.js
@@ -182,17 +182,7 @@
             that.$element.find("option[value='"+option.value+"']").length === 0){
           var $option = $('<option value="'+option.value+'">'+option.text+'</option>'),
               $container = option.nested === undefined ? that.$element : $("optgroup[label='"+option.nested+"']"),
-              index;
-
-          if(typeof option.index === 'undefined'){
-            if(typeof option.nested !== 'undefined' && option.nested !== null){
-              index = that.$element.children('[label="' + option.nested + '"]').children().length;
-            } else {
-              index = that.$element.children().length;
-            }
-          } else {
-            index = parseInt(option.index);
-          }
+              index = parseInt((typeof option.index === 'undefined' ? $container.children().length : option.index));
 
           $option.insertAt(index, $container);
           that.generateLisFromOption($option.get(0), index, option.nested);

--- a/js/jquery.multi-select.js
+++ b/js/jquery.multi-select.js
@@ -181,8 +181,18 @@
         if (option.value !== undefined && option.value !== null &&
             that.$element.find("option[value='"+option.value+"']").length === 0){
           var $option = $('<option value="'+option.value+'">'+option.text+'</option>'),
-              index = parseInt((typeof option.index === 'undefined' ? that.$element.children().length : option.index)),
-              $container = option.nested === undefined ? that.$element : $("optgroup[label='"+option.nested+"']");
+              $container = option.nested === undefined ? that.$element : $("optgroup[label='"+option.nested+"']"),
+              index;
+
+          if(typeof option.index === 'undefined'){
+            if(typeof option.nested !== 'undefined' && option.nested !== null){
+              index = that.$element.children('[label="' + option.nested + '"]').children().length;
+            } else {
+              index = that.$element.children().length;
+            }
+          } else {
+            index = parseInt(option.index);
+          }
 
           $option.insertAt(index, $container);
           that.generateLisFromOption($option.get(0), index, option.nested);


### PR DESCRIPTION
Fixed an issue where addOption would not find the proper place to insert into when optgroups are specified & index is not.
Example here: https://jsfiddle.net/me8v1fyp/

The index calculation doesn't recognize that `that.$element.children()` is the list of optgroups when they are specified, so it places the new option after the last optgroup - instead of entering the specified group (`nested`) to insert into.
