### PR TITLE
Reset previous selection when repeating calls to multi-select

### DIFF
--- a/js/jquery.multi-select.js
+++ b/js/jquery.multi-select.js
@@ -88,6 +88,11 @@
       }
 
       var selectedValues = ms.find('option:selected').map(function(){ return $(this).val(); }).get();
+
+      // Make sure to deselected all previously selected item (if any)
+      // before selecting items that should be selected indeed.
+      that.deselect_all();
+
       that.select(selectedValues, 'init');
 
       if (typeof that.options.afterInit === 'function') {


### PR DESCRIPTION
When multi-select is called several times on the same 'select' HTML
element (e.g. when this 'select' element is updated with fresh data
from a database each time it is displayed), it is necessary to
reset previous selections (if any) before processing current
selected / unselected items, otherwise items that were previously in the class
'ms-selected' will remain in this class, and will therefore be
(wrongly) displayed as selected.