### PR TITLE
Fixing the moving to left issue

### DIFF
--- a/js/jquery.multi-select.js
+++ b/js/jquery.multi-select.js
@@ -37,7 +37,7 @@
           ms = this.$element;
 
       if (ms.next('.ms-container').length === 0){
-        ms.css({ position: 'absolute', left: '-9999px' });
+        ms.css({ position: 'absolute', display: 'none' });
         ms.attr('id', ms.attr('id') ? ms.attr('id') : Math.ceil(Math.random()*1000)+'multiselect');
         this.$container.attr('id', 'ms-'+ms.attr('id'));
         this.$container.addClass(that.options.cssClass);


### PR DESCRIPTION
when calling the **multi-select** for the second time and more, the whole page goes left and causes problems. even if I remove the select and the div that multi-select has generated, still the problem is there.
This line is causing the issue :
`ms.css({ position: 'absolute', left: '-9999px' });`
has been edited to :
`ms.css({ position: 'absolute', display: 'none' });`