### PR TITLE
single and double click event handlers - singleDblClick builds on the dblClick feature

### DIFF
--- a/js/jquery.multi-select.js
+++ b/js/jquery.multi-select.js
@@ -69,15 +69,35 @@
 
         that.activeMouse(that.$selectableUl);
         that.activeKeyboard(that.$selectableUl);
+        
+        if (that.options.singleDblClick) {
+          that.$selectableUl.on('click', '.ms-elem-selectable', function(){
+            if (typeof that.options.beforeSelect === 'function') {
+              that.options.beforeSelect.call(this, $(this).data('ms-value'));
+            }
+          });
+          that.$selectionUl.on('click', '.ms-elem-selection', function(){
+            if (typeof that.options.beforeDeselect === 'function') {
+              that.options.beforeDeselect.call(this, $(this).data('ms-value'));
+            }
+          });
+          that.$selectableUl.on('dblclick', '.ms-elem-selectable', function(){
+            that.select($(this).data('ms-value'));
+          });
+          that.$selectionUl.on('dblclick', '.ms-elem-selection', function(){
+            that.deselect($(this).data('ms-value'));
+          });
+        } 
+        else {
+          var action = that.options.dblClick ? 'dblclick' : 'click';
 
-        var action = that.options.dblClick ? 'dblclick' : 'click';
-
-        that.$selectableUl.on(action, '.ms-elem-selectable', function(){
-          that.select($(this).data('ms-value'));
-        });
-        that.$selectionUl.on(action, '.ms-elem-selection', function(){
-          that.deselect($(this).data('ms-value'));
-        });
+          that.$selectableUl.on(action, '.ms-elem-selectable', function(){
+            that.select($(this).data('ms-value'));
+          });
+          that.$selectionUl.on(action, '.ms-elem-selection', function(){
+            that.deselect($(this).data('ms-value'));
+          });
+        }
 
         that.activeMouse(that.$selectionUl);
         that.activeKeyboard(that.$selectionUl);
@@ -525,6 +545,7 @@
     selectableOptgroup: false,
     disabledClass : 'disabled',
     dblClick : false,
+    singleDblClick : false,
     keepOrder: false,
     cssClass: ''
   };


### PR DESCRIPTION
addresses: [Feature request 286](https://github.com/lou/multi-select/issues/286)

ability to have event handlers for both single and double click - singleDblClick builds on dblClick  by adding two more event handlers .. beforeSelect and beforeDeselect
example usage:

```javascript
$('#my-select').multiSelect({
            singleDblClick: true, 
            beforeSelect: function(values){}, 
            beforeDeselect: function(values){},
            afterSelect: function(values){},
            afterDeselect: function(values){}
       })
```