### PR TITLE
Modify the hash function,Avoid common hash conflicts

### DIFF
--- a/js/jquery.multi-select.js
+++ b/js/jquery.multi-select.js
@@ -486,15 +486,12 @@
     },
 
     sanitize: function(value){
-      var hash = 0, i, character;
-      if (value.length == 0) return hash;
-      var ls = 0;
-      for (i = 0, ls = value.length; i < ls; i++) {
-        character  = value.charCodeAt(i);
-        hash  = ((hash<<5)-hash)+character;
-        hash |= 0; // Convert to 32bit integer
+      var hash = 5381, index = value.length;
+      while (index) {
+        hash = (hash * 33) ^ value.charCodeAt(--index);
       }
-      return hash;
+
+      return hash >>> 0;
     }
   };
 


### PR DESCRIPTION
In Chinese, "枣庄" and "无锡" are very common cities, but the original sanitize function will cause hash conflicts.
![qq 20181219222407](https://user-images.githubusercontent.com/4156079/50226096-4f9f3380-03dd-11e9-810a-e5e4e2683be1.jpg)
