### PR TITLE
prop() instead of attr() for regular control

### DIFF
--- a/js/jquery.multi-select.js
+++ b/js/jquery.multi-select.js
@@ -372,7 +372,7 @@
         selectables.addClass('ms-selected').hide();
         selections.addClass('ms-selected').show();
 
-        options.attr('selected', 'selected');
+        options.prop('selected', 'selected');
 
         that.$container.find(that.elemsSelector).removeClass('ms-hover');
 


### PR DESCRIPTION
The proper way to select values in prop(), instead of attr(). Values which has been set up with attr() cannot be cleared!!
And this is big problem that cost more than 10 hours of my life today and before when I did not believe in this bug and tried many workarounds!