### PR TITLE
Allow HTML to be set as item content

### DIFF
--- a/js/jquery.multi-select.js
+++ b/js/jquery.multi-select.js
@@ -108,7 +108,8 @@
           attributes += attr.name+'="'+attr.value+'" ';
         }
       }
-      var selectableLi = $('<li '+attributes+'><span>'+that.escapeHTML($option.text())+'</span></li>'),
+      var content = $option.data('html') ?? '<span>' + that.escapeHTML($option.text()) + '</span>';
+      var selectableLi = $('<li ' + attributes + '>' + content + '</li>'),
           selectedLi = selectableLi.clone(),
           value = $option.val(),
           elementId = that.sanitize(value);


### PR DESCRIPTION
Allow using HTML as list item content by using `data-html` option's attribute, if set